### PR TITLE
Making usb boot target more flexible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,13 @@ all_targets: $(TARGETS)
 
 check: $(TESTS:=.run)
 
-usb_e: tools/set_boot.exe boot/boot.bin boot/loader.bin kernel/kernel.bin
-	tools/set_boot.exe //./e: boot/boot.bin
-	cp boot/loader.bin e:/
-	cp kernel/kernel.bin e:/
+usb_boot_c: tools/set_boot.exe boot/boot.bin boot/loader.bin kernel/kernel.bin
+	@echo "Unable to make the C: drive a PDOS boot disk"
+
+usb_boot_%: tools/set_boot.exe boot/boot.bin boot/loader.bin kernel/kernel.bin
+	tools/set_boot.exe //./$*: boot/boot.bin
+	cp boot/loader.bin $*:/
+	cp kernel/kernel.bin $*:/
 
 clean:
 	rm -f */*.bin */*.exe */*.exe.run */*.o */*.d


### PR DESCRIPTION
Updating the makefile to support a variable for the drive letter you
want to make bootable. This saves people from adding every removable
drive letter to the makefile.

Added a specific target for the c: drive since that shouldn't ever be
written.

Really the shortcut target to make a bootable disk is pretty scary and
could probably be a utility instead of a makefile target.
